### PR TITLE
Make Point be able to take ownership of `measurement`

### DIFF
--- a/src/data_model/data_points.rs
+++ b/src/data_model/data_points.rs
@@ -38,9 +38,9 @@ pub struct Point<'a> {
 
 impl<'a> Point<'a> {
     /// Create a new point
-    pub fn new(measurement: &str) -> Point {
+    pub fn new<T: Into<String>>(measurement: T) -> Point<'a> {
         Point {
-            measurement: String::from(measurement),
+            measurement: measurement.into(),
             tags: HashMap::new(),
             fields: HashMap::new(),
             timestamp: None,


### PR DESCRIPTION
`Point` currently doesn't take ownership of the `measurement` variable that's passed in. This results in complications when dealing with something like:

```
let mut points = Points::create_new(Vec::new());

for i in 0..3 {
    let measurement = format!("{}_point", i);
    points = points.push(Point::new(measurement)......);
}

do_something_with(points);
```

In this scenario, `measurement` will go out of scope each time it iterates through the loop.
This change makes it so that `new` can take ownership of what's passed in in the same way that `add_field` and other functions can.